### PR TITLE
templates: make service type name harder to collide

### DIFF
--- a/templates/server.gotmpl
+++ b/templates/server.gotmpl
@@ -106,10 +106,10 @@ func NewRPCError(code int, msg string) *RPCError {
 }
 
 type Server struct {
-	service Service
+	service GoOpenRPCService
 }
 
-func NewServer(rpc Service) *Server {
+func NewServer(rpc GoOpenRPCService) *Server {
 	return &Server{rpc}
 }
 

--- a/templates/types.gotmpl
+++ b/templates/types.gotmpl
@@ -2,7 +2,7 @@
 
 package main
 
-type Service interface {
+type GoOpenRPCService interface {
 {{- range .Methods }}
 {{- $name := .Name | camelCase }}
 {{- $params := (maybeMethodParams .) }}


### PR DESCRIPTION
Ran into issue when using the cli-gen command
with [jade-service-runner](https://github.com/etclabscore/jade-service-runner/blob/master/openrpc.json) where the name 'Service'
collided with that package's Service object.